### PR TITLE
Update LICENSE and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    labels:
-      - dependabot
-      - actions
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /
-    labels:
-      - dependabot
-      - docker
     schedule:
-      interval: daily
+      interval: weekly

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
+MIT License
 
-The MIT License (MIT)
-
-Copyright (c) 2018 GitHub, Inc. and contributors
+Copyright GitHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR does the following:

- Updates `LICENSE` to GitHub's standard MIT license
- Changes the Dependabot configuration to run weekly
- Removes the additional labels added by Dependabot (as they may not exist in developers' new repos)