### PR TITLE
Document CODEOWNERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ This action prints `Hello, World!` or `Hello, <who-to-greet>!` to the log. To
 learn how this action was built, see
 [Creating a Docker container action](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action).
 
+## Create Your Own Action
+
+To create your own action, you can use this repository as a template! Just
+follow the below instructions:
+
+1. Click the **Use this template** button at the top of the repository
+1. Select **Create a new repository**
+1. Select an owner and name for your new repository
+1. Click **Create repository**
+1. Clone your new repository
+
+> [!CAUTION]
+>
+> Make sure to remove or update the [`CODEOWNERS`](./CODEOWNERS) file! For
+> details on how to use this file, see
+> [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+
 ## Usage
 
 Here's an example of how to use this action in a workflow file:


### PR DESCRIPTION
This PR adds a call out in the README that the CODEOWNERS file should be removed or modified when the template repo is copied.